### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Developed in .NET Framework 4.8, using SQL Server and Dapper NuGet.
 
 ### Why Dapper?
-Because it is "King of Micro ORM" in terms of speed and performance. Also, it is developed by Stack Overflow developers and doesn't going anywhere any time soon.
+Because it is "King of Micro ORM" in terms of speed and performance. Also, it is developed by Stack Overflow developers and isn't going anywhere any time soon.
 Implementation is relatively simple than Entity Framework and ADO.NET for a small project. It can work after three-step process:
 - Create an IDbConnection object.
 - Write a query to perform CRUD operations.


### PR DESCRIPTION
## Summary
- fix grammar mistake in the Dapper section of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68837573e5208329b46dd347d90e2170